### PR TITLE
setting grad None after training to avoid memory leak

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ for i in range(1, EPOCHS+1):
         running_loss += loss.item() * features_.size(0)
     train_loss = running_loss / len(dl_train.dataset)
     print("EPOCH: {}, TRAIN LOSS: {}".format(i, train_loss))
+# set grad to None to avoid memory leak
+mw.end()
 ```
 Note that on the first step of the train loop PyTorch will return the following warning:
 ```

--- a/src/gradient_descent_the_ultimate_optimizer/gdtuo.py
+++ b/src/gradient_descent_the_ultimate_optimizer/gdtuo.py
@@ -51,6 +51,14 @@ class Optimizable:
         ''' Update parameters '''
         pass
 
+    def end(self):
+        if hasattr(self, "all_params_with_gradients"):
+            for param in self.all_params_with_gradients:
+                param.grad = None
+            self.all_params_with_gradients.clear()
+        if hasattr(self, "optimizer"):
+            self.optimizer.end()
+
 class NoOpOptimizer(Optimizable):
     '''
     NoOpOptimizer sits on top of a stack, and does not affect what lies below.


### PR DESCRIPTION
Hi,

during training I've observed a memory leak, when training several models after another. I've used your example code from the Readme to create an example, see below. I'm using Python 3.7 and PyTorch 1.13.1. Per training run I observe an increase of about 10MiB concerning memory usage. This is especially an issue when training larger models, resulting in an out of memory error. 

The memory leak is discussed in https://github.com/pytorch/pytorch/issues/82528. In your code there is already a `begin` method in the `Optimizable` class which sets the `param.grad` to None. However, it seems there is also a need to set `param.grad=None` at the end of training a model to avoid memory leakage over several training runs. Hence, I suggest to add an end method which is called at the end of each training run.


```python
import math
import torch
import torch.nn as nn
import torch.nn.functional as F

class MNIST_FullyConnected(nn.Module):
    """
    A fully-connected NN for the MNIST task. This is Optimizable but not itself
    an optimizer.
    """
    def __init__(self, num_inp, num_hid, num_out):
        super(MNIST_FullyConnected, self).__init__()
        self.layer1 = nn.Linear(num_inp, num_hid)
        self.layer2 = nn.Linear(num_hid, num_out)

    def initialize(self):
        nn.init.kaiming_uniform_(self.layer1.weight, a=math.sqrt(5))
        nn.init.kaiming_uniform_(self.layer2.weight, a=math.sqrt(5))

    def forward(self, x):
        """Compute a prediction."""
        x = self.layer1(x)
        x = torch.tanh(x)
        x = self.layer2(x)
        x = torch.tanh(x)
        x = F.log_softmax(x, dim=1)
        return x

def train_model(model_wrapper, train_data):
    for i in range(1, EPOCHS + 1):
        running_loss = 0.0
        for j, (features_, labels_) in enumerate(train_data):
            model_wrapper.begin()  # call this before each step, enables gradient tracking on desired params
            features, labels = torch.reshape(features_, (-1, 28 * 28)).to(
                DEVICE
            ), labels_.to(DEVICE)
            pred = model_wrapper.forward(features)
            loss = F.nll_loss(pred, labels)
            model_wrapper.zero_grad()
            loss.backward(create_graph=True)  # important! use create_graph=True
            # loss.backward(create_graph=False) # important! use create_graph=True
            model_wrapper.step()
            running_loss += loss.item() * features_.size(0)
        train_loss = running_loss / len(train_data.dataset)
        print("EPOCH: {}, TRAIN LOSS: {}".format(i, train_loss))

if __name__ == "__main__":
    import torchvision
    from gradient_descent_the_ultimate_optimizer import gdtuo

    BATCH_SIZE = 256
    EPOCHS = 2
    N_RUNS = 50
    DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
    for i_run in range(N_RUNS):
        print(f"Run: {i_run}")
        mnist_train = torchvision.datasets.MNIST(
            "./data",
            train=True,
            download=True,
            transform=torchvision.transforms.ToTensor(),
        )
        dl_train = torch.utils.data.DataLoader(
            mnist_train, batch_size=BATCH_SIZE, shuffle=True
        )
        model = MNIST_FullyConnected(28 * 28, 128, 10).to(DEVICE)
        optim = gdtuo.Adam(optimizer=gdtuo.SGD(1e-5))

        mw = gdtuo.ModuleWrapper(model, optimizer=optim)
        mw.initialize()
        train_model(mw, dl_train)
```